### PR TITLE
Seperate profies and add application.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,15 @@ SpringBoot 자동설정
 2. Entity && JPARepository
 
 3. Seperate profiles
-
+  - create application-local (개발시 로컬 서버), application-dev(개발전 서버), application-prod (실제 서버)
+   1. application.yml
+    - ```
+      spring:
+        profiles:
+          active: dev
+      ```
+      로 active를 바꿔주기만 하면 사용가능하다.
+   2. 
 4. MyBatis
 
 5. Paging && Search

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,14 @@
+spring:
+    datasource:
+        url: jdbc:mariadb://localhost:3306/testdb
+        driver-class-name: org.mariadb.jdbc.Driver
+        username: root
+        password: 1234
+    jpa:
+        database-platform: org.hibernate.dialect.MariaDBDialect
+        properties:
+            hibernate:
+                show-sql: true
+                format-sql: true
+        hibernate: 
+            ddl-auto: create-drop

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,19 @@
+spring:
+    h2:
+        console:
+            enabled: true
+            path: /h2-console
+    datasource:
+        url: jdbc:h2:~/test;
+        driver-class-name: org.h2.Driver
+        username: root
+        password: 1234
+    jpa:
+        database-platform: org.hibernate.dialect.H2Dialect
+        properties:
+            hibernate:
+                dialect: org.hibernate.dialect.H2Dialect
+                show-sql: true
+                format-sql: true
+        hibernate: 
+            ddl-auto: create-drop

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,19 @@
+spring:
+    h2:
+        console:
+            enabled: true
+            path: /h2-console
+    datasource:
+        url: jdbc:h2:~/test;
+        driver-class-name: org.h2.Driver
+        username: root
+        password: 1234
+    jpa:
+        database-platform: org.hibernate.dialect.H2Dialect
+        properties:
+            hibernate:
+                dialect: org.hibernate.dialect.H2Dialect
+                show-sql: true
+                format-sql: true
+        hibernate: 
+            ddl-auto: create-drop

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,19 +1,3 @@
 spring:
-    h2:
-        console:
-            enabled: true
-            path: /h2-console
-    datasource:
-        url: jdbc:h2:~/test;
-        driver-class-name: org.h2.Driver
-        username: root
-        password: 1234
-    jpa:
-        database-platform: org.hibernate.dialect.H2Dialect
-        properties:
-            hibernate:
-                dialect: org.hibernate.dialect.H2Dialect
-                show-sql: true
-                format-sql: true
-        hibernate: 
-            ddl-auto: create-drop
+    profiles:
+        active: dev


### PR DESCRIPTION
Learn how to separate profiles
 - add local application.yml
 ```
  spring:
    profiles:
        active: local
 ```
 - add application-dev, application-local, application-prod .yml 
 - set individual yml setting ex ...
 ```
 spring:
    datasource:
        url: jdbc:mariadb://localhost:3306/testdb
        driver-class-name: org.mariadb.jdbc.Driver
        username: 'username for db'
        password: 'password db'
    jpa:
        database-platform: org.hibernate.dialect.MariaDBDialect
        properties:
            hibernate:
                show-sql: true
                format-sql: true
        hibernate: 
            ddl-auto: create-drop
 ```

 - When want running other application.yml just change application.yml, active: local || dev || prod depends what you working on